### PR TITLE
Use PGobject.setType("inet") in InetAddressType

### DIFF
--- a/src/main/java/com/github/thealchemist/pg_hibernate/InetAddressType.java
+++ b/src/main/java/com/github/thealchemist/pg_hibernate/InetAddressType.java
@@ -64,6 +64,7 @@ public class InetAddressType implements UserType {
 		} else {
 			PGobject object = new PGobject();
 			object.setValue(((InetAddress) o).getHostAddress());
+			object.setType("inet");
 			preparedStatement.setObject(i, object);
 		}
 	}


### PR DESCRIPTION
Fixes the following exception:

```
java.lang.NullPointerException
	at org.postgresql.jdbc.TypeInfoCache.getOidStatement(TypeInfoCache.java:262)
	at org.postgresql.jdbc.TypeInfoCache.getPGType(TypeInfoCache.java:366)
	at org.postgresql.jdbc.PgPreparedStatement.setPGobject(PgPreparedStatement.java:534)
	at org.postgresql.jdbc.PgPreparedStatement.setObject(PgPreparedStatement.java:1022)
	at com.qadium.etl.dao.InetAddressType.nullSafeSet(InetAddressType.java:68)
        . . .
```